### PR TITLE
[#38] fix: 브랜치 이름 생성에 큰따옴표 추가

### DIFF
--- a/.github/workflows/jira-issue-sync.yml
+++ b/.github/workflows/jira-issue-sync.yml
@@ -56,5 +56,5 @@ jobs:
           TITLE=${{ github.event.issue.title }}
           ISSUE_NUMBER=${{ github.event.issue.number }}
           BRANCH_NAME=${LABEL}/${TICKET_NUMBER}-$(echo $TITLE | tr ' ' '-' | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]-')#${ISSUE_NUMBER}
-          git checkout -b ${BRANCH_NAME}
-          git push origin ${BRANCH_NAME}
+          git checkout -b "${BRANCH_NAME}"
+          git push origin "${BRANCH_NAME}"


### PR DESCRIPTION
Closes #38

## Overview
이슈가 발행되었을 때 브랜치가 생성되지 않는 오류 해결

## PR Type
어떤 변경 사항이 있나요?

- [ ] feat
- [x] fix
- [ ] chore
- [ ] refactoring
- [ ] documentation
- [ ] tests
- [ ] build
- [ ] modify files
- [ ] delete files

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
