### PR TITLE
[#85] feat: Prometheus를 위한 설정 추가

### DIFF
--- a/status/build.gradle
+++ b/status/build.gradle
@@ -56,6 +56,12 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// actuator
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	// prometheus
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 dependencyManagement {

--- a/status/src/main/resources/application.yaml
+++ b/status/src/main/resources/application.yaml
@@ -18,3 +18,10 @@ logging:
 springdoc:
   swagger-ui:
     path: '/docs'
+
+management:
+  endpoints:
+    web:
+      base-path: /prom
+      exposure:
+        include: prometheus


### PR DESCRIPTION
Closes #85

# 📋 내용

<!-- 작업 내용을 여기에 적어주세요 -->
- `spring-boot-starter-actuator`와 `micrometer-registry-prometheus` 의존성을 추가하여 애플리케이션의 상태를 모니터링할 수 있는 기능 활성화
- `application.yml` 파일에 Prometheus 익스포터 설정을 추가하여 /prom 경로로 메트릭을 노출하도록 구성

# 🚨 유의 사항

<!-- 리뷰어가 알아야 하는 내용이 있다면 여기 적어주세요 -->
- 메트릭을 수집할 때 `[애플리케이션_URL]/prom/prometheus` 경로 사용
