### PR TITLE
Feat/nvs 140 controlleradvice로 에러 관리#84

### DIFF
--- a/status/src/main/java/com/neves/status/controller/BlackboxController.java
+++ b/status/src/main/java/com/neves/status/controller/BlackboxController.java
@@ -10,11 +10,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
-import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -45,12 +42,8 @@ public class BlackboxController {
 	) {
 		log.info("(Registering blackbox) request: {}", request);
 		String userId = JwtUtils.extractUserIdFromJwt(jwtToken);
-		try {
-			BlackboxResponseDto response = blackboxService.register(userId, request);
-			return ResponseEntity.ok(response);
-		} catch (IllegalArgumentException e) {
-			return ResponseEntity.status(HttpStatus.CONFLICT).build();
-		}
+		BlackboxResponseDto response = blackboxService.register(userId, request);
+		return ResponseEntity.ok(response);
 	}
 
 	@Operation(summary="블랙박스 이름 변경", description="등록된 블랙박스의 이름을 변경합니다.")
@@ -62,13 +55,9 @@ public class BlackboxController {
 	public ResponseEntity<Object> rename(
 			@PathVariable("blackbox_id") String blackboxId,
 			@RequestBody BlackboxRenameRequestDto request) {
-		try {
-			log.info("(Renaming blackbox) blackboxId: {}, request: {}", blackboxId, request);
-			BlackboxResponseDto response = blackboxService.rename(blackboxId, request);
-			return ResponseEntity.ok(response);
-		} catch (NoSuchElementException e) {
-			return ResponseEntity.notFound().build();
-		}
+		log.info("(Renaming blackbox) blackboxId: {}, request: {}", blackboxId, request);
+		BlackboxResponseDto response = blackboxService.rename(blackboxId, request);
+		return ResponseEntity.ok(response);
 	}
 
 	@Operation(summary="유저의 블랙박스 목록 조회", description="특정 유저가 등록한 모든 블랙박스의 목록을 조회합니다.")
@@ -93,11 +82,7 @@ public class BlackboxController {
 	public ResponseEntity<BlackboxResponseDto> getBlackboxStatus(
 			@PathVariable("blackbox_id") String blackboxId) {
 		log.info("(Getting blackbox status) blackboxId: {}", blackboxId);
-		try {
-			BlackboxResponseDto response = blackboxService.getBlackboxStatus(blackboxId);
-			return ResponseEntity.ok(response);
-		} catch (NoSuchElementException e) {
-			return ResponseEntity.notFound().build();
-		}
+		BlackboxResponseDto response = blackboxService.getBlackboxStatus(blackboxId);
+		return ResponseEntity.ok(response);
 	}
 }

--- a/status/src/main/java/com/neves/status/controller/MetadataController.java
+++ b/status/src/main/java/com/neves/status/controller/MetadataController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
@@ -58,11 +57,8 @@ public class MetadataController {
 			LocalDateTime date
 	) {
 		log.info("(Listing metadata) blackboxId: {}, date: {}", blackboxId, date);
-		try {
-			return ResponseEntity.ok(metadataService.list(blackboxId, date));
-		} catch (NoSuchElementException e) {
-			return ResponseEntity.notFound().build();
-		}
+		List<MetadataResponse> response = metadataService.list(blackboxId, date);
+		return ResponseEntity.ok(response);
 	}
 
 	@Operation(summary = "영상 삭제", description = "특정 영상을 삭제합니다.")
@@ -77,12 +73,8 @@ public class MetadataController {
 			String videoId
 	) {
 		log.info("(Deleting metadata) video_id: {}", videoId);
-		try {
-			metadataService.delete(videoId);
-			return ResponseEntity.noContent().build();
-		} catch (NoSuchElementException e) {
-			return ResponseEntity.notFound().build();
-		}
+		metadataService.delete(videoId);
+		return ResponseEntity.noContent().build();
 	}
 
 }

--- a/status/src/main/java/com/neves/status/handler/ErrorMessage.java
+++ b/status/src/main/java/com/neves/status/handler/ErrorMessage.java
@@ -1,0 +1,22 @@
+package com.neves.status.handler;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorMessage {
+    //Blackbox
+    BLACKBOX_NOT_FOUND("UUID에 해당하는 블랙박스를 찾을 수 없습니다. UUID: %s"),
+    ALREADY_REGISTERED_BLACKBOX("이미 등록된 블랙박스입니다."),
+
+    //Metadata
+    METADATA_NOT_FOUND("ID에 해당하는 메타데이터를 찾을 수 없습니다. ID: %s");
+
+    private final String message;
+
+    public String getMessage(Object... args) {
+        return String.format(this.message, args);
+    }
+}

--- a/status/src/main/java/com/neves/status/handler/ErrorResponse.java
+++ b/status/src/main/java/com/neves/status/handler/ErrorResponse.java
@@ -1,0 +1,23 @@
+package com.neves.status.handler;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorResponse {
+
+    private final int status;
+    private final String error;
+    private final String message;
+
+    public static ErrorResponse of(HttpStatus status, String message) {
+        return ErrorResponse.builder()
+                .status(status.value())
+                .error(status.getReasonPhrase())
+                .message(message)
+                .build();
+    }
+}

--- a/status/src/main/java/com/neves/status/handler/GlobalExceptionHandler.java
+++ b/status/src/main/java/com/neves/status/handler/GlobalExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.neves.status.handler;
+
+
+import java.util.NoSuchElementException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 404 NotFound
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<ErrorResponse> handleNoSuchElementException(NoSuchElementException e) {
+        log.error("Resource not found: {}", e.getMessage());
+        ErrorResponse response = ErrorResponse.of(HttpStatus.NOT_FOUND, e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
+    // 500 Internal Server Error
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Unhandled exception occurred: {}", e.getMessage(), e);
+        ErrorResponse response = ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 예상치 못한 오류가 발생했습니다.");
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    // 409 Conflict
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn("Illegal argument / Conflict: {}", e.getMessage());
+        ErrorResponse response = ErrorResponse.of(HttpStatus.CONFLICT, e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.CONFLICT);
+    }
+
+
+}

--- a/status/src/main/java/com/neves/status/service/BlackboxService.java
+++ b/status/src/main/java/com/neves/status/service/BlackboxService.java
@@ -4,6 +4,7 @@ import com.neves.status.controller.dto.blackbox.BlackboxRegisterRequestDto;
 import com.neves.status.controller.dto.blackbox.BlackboxRenameRequestDto;
 import com.neves.status.controller.dto.blackbox.BlackboxResponseDto;
 import com.neves.status.controller.dto.blackbox.BlackboxStatus;
+import com.neves.status.handler.ErrorMessage;
 import com.neves.status.repository.Blackbox;
 import com.neves.status.repository.BlackboxRepository;
 import com.neves.status.repository.Metadata;
@@ -29,7 +30,7 @@ public class BlackboxService {
     @Transactional
     public BlackboxResponseDto register(String userId, BlackboxRegisterRequestDto request) {
         if (blackboxRepository.findByUuid(request.getUuid()).isPresent()) {
-            throw new IllegalArgumentException("이미 등록된 블랙박스입니다.");
+            throw new IllegalArgumentException(ErrorMessage.ALREADY_REGISTERED_BLACKBOX.getMessage());
         }
 
         Blackbox newBlackbox = Blackbox.builder()
@@ -46,7 +47,7 @@ public class BlackboxService {
     @Transactional
     public BlackboxResponseDto rename(String blackboxId, BlackboxRenameRequestDto request) {
         Blackbox blackbox = blackboxRepository.findByUuid(blackboxId)
-                .orElseThrow(() -> new NoSuchElementException("블랙박스를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NoSuchElementException(ErrorMessage.BLACKBOX_NOT_FOUND.getMessage(blackboxId)));
 
         blackbox.setNickname(request.getNickname());
 
@@ -65,7 +66,7 @@ public class BlackboxService {
     @Transactional(readOnly = true)
     public BlackboxResponseDto getBlackboxStatus(String blackboxId) {
         Blackbox blackbox = blackboxRepository.findByUuid(blackboxId)
-                .orElseThrow(() -> new NoSuchElementException("블랙박스를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NoSuchElementException(ErrorMessage.BLACKBOX_NOT_FOUND.getMessage(blackboxId)));
 
         return mapToDtoWithHealthStatus(blackbox, LocalDateTime.now());
     }

--- a/status/src/main/java/com/neves/status/service/MetadataService.java
+++ b/status/src/main/java/com/neves/status/service/MetadataService.java
@@ -54,11 +54,12 @@ public class MetadataService {
 	}
 
 	public void delete(String metadataId) {
-		repository.findById(metadataId).ifPresent(metadata -> {
+		repository.findById(metadataId).map(metadata -> {
 			if (!metadata.isDeleted()) {
 				metadata.setDeleted(true);
 			}
-		});
+			return metadata;
+		}).orElseThrow(() -> new NoSuchElementException(ErrorMessage.METADATA_NOT_FOUND.getMessage(metadataId)));
 	}
 
 	private List<MetadataResponse> toResponseList(List<Metadata> metadataList) {

--- a/status/src/main/java/com/neves/status/service/MetadataService.java
+++ b/status/src/main/java/com/neves/status/service/MetadataService.java
@@ -2,6 +2,7 @@ package com.neves.status.service;
 
 import com.neves.status.controller.dto.blackbox.MetadataRegisterRequest;
 import com.neves.status.controller.dto.metadata.MetadataResponse;
+import com.neves.status.handler.ErrorMessage;
 import com.neves.status.repository.Blackbox;
 import com.neves.status.repository.BlackboxRepository;
 import com.neves.status.repository.Metadata;
@@ -11,7 +12,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,7 +25,7 @@ public class MetadataService {
 
 	public void create(UUID metadataId, MetadataRegisterRequest request) {
 		Blackbox blackbox = blackboxRepository.findByUuid(request.getBlackboxUuid())
-				.orElseThrow(() -> new IllegalArgumentException("UUID에 해당하는 블랙박스를 찾을 수 없습니다. UUID: : " + request.getBlackboxUuid()));
+				.orElseThrow(() -> new IllegalArgumentException(ErrorMessage.BLACKBOX_NOT_FOUND.getMessage(request.getBlackboxUuid())));
 
 		Metadata metadata = Metadata.builder()
 				.id(metadataId.toString())
@@ -42,7 +42,7 @@ public class MetadataService {
 
 	public List<MetadataResponse> list(String blackboxId, LocalDateTime targetDate) {
 		blackboxRepository.findByUuid(blackboxId)
-				.orElseThrow(() -> new NoSuchElementException("UUID에 해당하는 블랙박스를 찾을 수 없습니다. UUID: : " + blackboxId));
+				.orElseThrow(() -> new NoSuchElementException(ErrorMessage.BLACKBOX_NOT_FOUND.getMessage(blackboxId)));
 		LocalDateTime startOfDay = targetDate.toLocalDate().atStartOfDay();
 		LocalDateTime endOfDay = startOfDay.plusDays(1).minusNanos(1);
 		List<Metadata> metadataList = repository.findByBlackboxUuidBetween(
@@ -54,12 +54,11 @@ public class MetadataService {
 	}
 
 	public void delete(String metadataId) {
-		Metadata metadata = repository.findById(metadataId).orElseThrow(()
-				-> new NoSuchElementException("ID에 해당하는 메타데이터를 찾을 수 없습니다. ID: " + metadataId));
-		if (metadata.isDeleted()) {
-			throw new NoSuchElementException("ID에 해당하는 메타데이터를 찾을 수 없습니다. ID: " + metadataId);
-		}
-		metadata.setDeleted(true);
+		repository.findById(metadataId).ifPresent(metadata -> {
+			if (!metadata.isDeleted()) {
+				metadata.setDeleted(true);
+			}
+		});
 	}
 
 	private List<MetadataResponse> toResponseList(List<Metadata> metadataList) {


### PR DESCRIPTION
# 📋 내용

<!-- 작업 내용을 여기에 적어주세요 -->
- **공통 에러 응답 객체 `ErrorResponse` 추가**
    - 모든 API 에러 발생 시 일관된 JSON 형식(status, error, message)을 반환하기 위해 ErrorResponse DTO 추가
- **글로벌 예외 처리기 `GlobalExceptionHandler` 구현**
    - @RestControllerAdvice 사용하여 애플리케이션 전역에서 발생하는 예외를 처리하는 GlobalExceptionHandler 구현
    - NoSuchElementException(404), IllegalArgumentException(409) 등 주요 예외에 대한 처리 로직을 중앙화
- **컨트롤러 코드 간소화**
    - BlackboxController와 MetadataController의 모든 try-catch 구문을 제거하여 컨트롤러가 비즈니스 로직에만 집중할 수 있도록 코드를 정리
- **예외 메시지 중앙 관리 `ErrorMessage Enum`**
    - 전체 에러 목록을 한눈에 파악할 수 있도록 개선
- **MetadataService `delete` 메소드 수정**
    - ID 존재하지 않는 경우, orElseThrow로 404 에러 처리
    - **ID 존재하는 경우, isDeleted() 상태를 확인하여, 아직 삭제되지 않은 경우에만 true로 변경**
    - 이를 통해 이미 삭제된 데이터에 대한 요청에도 멱등성 보장

# 🚨 유의 사항

<!-- 리뷰어가 알아야 하는 내용이 있다면 여기 적어주세요 -->
