### PR TITLE
fix: 만약 요청에서 호출되는 now()가 아니라면 현재 시각이 비어있기 때문에 now()를 직접 호출하도록 변경

### DIFF
--- a/status/src/main/java/com/neves/status/config/CORSConfig.java
+++ b/status/src/main/java/com/neves/status/config/CORSConfig.java
@@ -1,0 +1,16 @@
+package com.neves.status.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CORSConfig implements WebMvcConfigurer {
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**")
+				.allowedOrigins("*")
+				.allowedMethods("*")
+				.allowedHeaders("*");
+	}
+}

--- a/status/src/main/java/com/neves/status/utils/CurrentTimeHolder.java
+++ b/status/src/main/java/com/neves/status/utils/CurrentTimeHolder.java
@@ -1,6 +1,7 @@
 package com.neves.status.utils;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 public abstract class CurrentTimeHolder {
 	private static final ThreadLocal<LocalDateTime> requestTimeHolder = new ThreadLocal<>();
@@ -14,6 +15,9 @@ public abstract class CurrentTimeHolder {
 	}
 
 	public static LocalDateTime now() {
+		if (Objects.isNull(requestTimeHolder.get())) {
+			return LocalDateTime.now();
+		}
 		return requestTimeHolder.get();
 	}
 }


### PR DESCRIPTION
# 📋 내용

스케줄러에서 돌아갈 때 now를 호출하면 작동하지 않는 오류를 수정했습니다.
