### PR TITLE
[#139] fix: 타임존 설정을 위해 docker이미지에 타임존 환경변수 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN ./gradlew bootJar --no-daemon
 
 FROM eclipse-temurin:21-jre-alpine
 
+ENV TZ=Asia/Seoul
+
 WORKDIR /app
 
 COPY --from=builder /app/build/libs/*.jar ./app.jar


### PR DESCRIPTION
Closes #139

# 📋 내용

타임존 설정을 위해 이미지에 타임존을 추가했습니다. (일종의 이미지 기본값을 서울로 한 것)
spring코드에 직접 넣는 것 보다는 환경변수로 설정하는 것이 더 좋다고 생각했습니다.