### PR TITLE
Feat/nvs 217 유저 인증 강화#137

### DIFF
--- a/status/src/main/java/com/neves/status/controller/BlackboxController.java
+++ b/status/src/main/java/com/neves/status/controller/BlackboxController.java
@@ -49,14 +49,17 @@ public class BlackboxController {
 	@Operation(summary="블랙박스 이름 변경", description="등록된 블랙박스의 이름을 변경합니다.")
 	@ApiResponses({
 			@ApiResponse(responseCode="200", description="블랙박스 이름 변경 성공"),
+			@ApiResponse(responseCode="403", description="권한 없음"),
 			@ApiResponse(responseCode="404", description="블랙박스를 찾을 수 없음")
 	})
 	@PutMapping("/{blackbox_id}")
 	public ResponseEntity<Object> rename(
 			@PathVariable("blackbox_id") String blackboxId,
-			@RequestBody BlackboxRenameRequestDto request) {
+			@RequestBody BlackboxRenameRequestDto request,
+			@RequestHeader(JwtUtils.JWT_HEADER) String jwtToken) {
 		log.info("(Renaming blackbox) blackboxId: {}, request: {}", blackboxId, request);
-		BlackboxResponseDto response = blackboxService.rename(blackboxId, request);
+		String userId = JwtUtils.extractUserIdFromJwt(jwtToken);
+		BlackboxResponseDto response = blackboxService.rename(userId, blackboxId, request);
 		return ResponseEntity.ok(response);
 	}
 

--- a/status/src/main/java/com/neves/status/controller/MetadataController.java
+++ b/status/src/main/java/com/neves/status/controller/MetadataController.java
@@ -3,6 +3,7 @@ package com.neves.status.controller;
 import com.neves.status.controller.dto.blackbox.MetadataRegisterRequest;
 import com.neves.status.controller.dto.metadata.MetadataResponse;
 import com.neves.status.service.MetadataService;
+import com.neves.status.utils.JwtUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -50,6 +52,7 @@ public class MetadataController {
 	})
 	@GetMapping
 	public ResponseEntity<List<MetadataResponse>> list(
+			@RequestHeader(JwtUtils.JWT_HEADER) String jwtToken,
 			@RequestParam
 			@Schema(description = "블랙박스 UUID", example = "123e4567-e89b-12d3-a456-426614174000")
 			String blackboxId,
@@ -58,7 +61,8 @@ public class MetadataController {
 			LocalDateTime date
 	) {
 		log.info("(Listing metadata) blackboxId: {}, date: {}", blackboxId, date);
-		List<MetadataResponse> response = metadataService.list(blackboxId, date);
+		String userId = JwtUtils.extractUserIdFromJwt(jwtToken);
+		List<MetadataResponse> response = metadataService.list(userId, blackboxId, date);
 		return ResponseEntity.ok(response);
 	}
 
@@ -69,12 +73,14 @@ public class MetadataController {
 	})
 	@DeleteMapping("/{videoId}")
 	public ResponseEntity<Void> delete(
+			@RequestHeader(JwtUtils.JWT_HEADER) String jwtToken,
 			@PathVariable
 			@Parameter(description = "삭제할 영상의 ID", example = "666a7b29a2862a5b67484344")
 			String videoId
 	) {
 		log.info("(Deleting metadata) video_id: {}", videoId);
-		metadataService.delete(videoId);
+		String userId = JwtUtils.extractUserIdFromJwt(jwtToken);
+		metadataService.delete(userId, videoId);
 		return ResponseEntity.noContent().build();
 	}
 

--- a/status/src/main/java/com/neves/status/handler/AuthorizationException.java
+++ b/status/src/main/java/com/neves/status/handler/AuthorizationException.java
@@ -1,0 +1,7 @@
+package com.neves.status.handler;
+
+public class AuthorizationException extends RuntimeException {
+    public AuthorizationException(String message) {
+        super(message);
+    }
+}

--- a/status/src/main/java/com/neves/status/handler/ErrorMessage.java
+++ b/status/src/main/java/com/neves/status/handler/ErrorMessage.java
@@ -10,6 +10,7 @@ public enum ErrorMessage {
     //Blackbox
     BLACKBOX_NOT_FOUND("UUID에 해당하는 블랙박스를 찾을 수 없습니다. UUID: %s"),
     ALREADY_REGISTERED_BLACKBOX("이미 등록된 블랙박스입니다."),
+    FORBIDDEN("해당 리소스에 접근할 권한이 없습니다."),
 
     //Metadata
     METADATA_NOT_FOUND("ID에 해당하는 메타데이터를 찾을 수 없습니다. ID: %s");

--- a/status/src/main/java/com/neves/status/handler/GlobalExceptionHandler.java
+++ b/status/src/main/java/com/neves/status/handler/GlobalExceptionHandler.java
@@ -28,5 +28,11 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.CONFLICT);
     }
 
+    @ExceptionHandler(AuthorizationException.class)
+    public ResponseEntity<ErrorResponse> handleAuthorizationException(AuthorizationException e) {
+        log.warn("Authorization failed: {}", e.getMessage());
+        ErrorResponse response = ErrorResponse.of(HttpStatus.FORBIDDEN, e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.FORBIDDEN);
+    }
 
 }

--- a/status/src/main/java/com/neves/status/service/BlackboxService.java
+++ b/status/src/main/java/com/neves/status/service/BlackboxService.java
@@ -4,6 +4,7 @@ import com.neves.status.controller.dto.blackbox.BlackboxRegisterRequestDto;
 import com.neves.status.controller.dto.blackbox.BlackboxRenameRequestDto;
 import com.neves.status.controller.dto.blackbox.BlackboxResponseDto;
 import com.neves.status.controller.dto.blackbox.BlackboxStatus;
+import com.neves.status.handler.AuthorizationException;
 import com.neves.status.handler.ErrorMessage;
 import com.neves.status.repository.Blackbox;
 import com.neves.status.repository.BlackboxRepository;
@@ -49,9 +50,13 @@ public class BlackboxService {
     }
 
     @Transactional
-    public BlackboxResponseDto rename(String blackboxId, BlackboxRenameRequestDto request) {
+    public BlackboxResponseDto rename(String userId, String blackboxId, BlackboxRenameRequestDto request) {
         Blackbox blackbox = blackboxRepository.findByUuid(blackboxId)
                 .orElseThrow(() -> new NoSuchElementException(ErrorMessage.BLACKBOX_NOT_FOUND.getMessage(blackboxId)));
+
+        if (!blackbox.getUserId().equals(userId)) {
+            throw new AuthorizationException(ErrorMessage.FORBIDDEN.getMessage());
+        }
 
         blackbox.setNickname(request.getNickname());
         Blackbox updatedBlackbox = blackboxRepository.save(blackbox);

--- a/status/src/test/java/com/neves/status/controller/MetadataControllerTest.java
+++ b/status/src/test/java/com/neves/status/controller/MetadataControllerTest.java
@@ -87,7 +87,8 @@ class MetadataControllerTest {
 		String url = BASE_URL + "?blackboxId=" + blackbox.getUuid() + "&date=" + day;
 
 		// when
-		String responseBody = mockMvc.perform(get(url))
+		String responseBody = mockMvc.perform(get(url)
+				.header(JwtUtils.JWT_HEADER, TestUtils.DEFAULT_JWT))
 			.andExpect(status().isOk())
 			.andReturn()
 			.getResponse()
@@ -110,8 +111,11 @@ class MetadataControllerTest {
 		String url = BASE_URL + "?blackboxId=" + "wrong-id" + "&date=" + day;
 
 		// when
-		mockMvc.perform(get(url))
-			.andExpect(status().isNotFound());
+		mockMvc.perform(get(url)
+                        .header(JwtUtils.JWT_HEADER, TestUtils.DEFAULT_JWT))
+				.andExpect(status().isNotFound());
+		// then
+		assertThat(metadataRepository.findById(metadata.getId())).isPresent();
 	}
 
 	@DisplayName("영상 삭제")
@@ -126,14 +130,16 @@ class MetadataControllerTest {
 		String url = BASE_URL + "/" + metadata.getId();
 
 		// when
-		mockMvc.perform(delete(url))
-			.andExpect(status().isNoContent());
+		mockMvc.perform(delete(url)
+                        .header(JwtUtils.JWT_HEADER, TestUtils.DEFAULT_JWT))
+				.andExpect(status().isNoContent());
 
 		// then
 		assertThat(metadataRepository.findById(metadata.getId()).map(Metadata::isDeleted).orElse(true)).isTrue();
-		mockMvc.perform(get(BASE_URL + "?blackboxId=" + blackbox.getUuid() + "&date=" + metadata.getCreatedAt().toLocalDate().atStartOfDay()))
-			.andExpect(status().isOk())
-			.andExpect(content().string("[]"));
+		mockMvc.perform(get(BASE_URL + "?blackboxId=" + blackbox.getUuid() + "&date=" + metadata.getCreatedAt().toLocalDate().atStartOfDay())
+				    .header(JwtUtils.JWT_HEADER, TestUtils.DEFAULT_JWT))
+                .andExpect(status().isOk())
+			    .andExpect(content().string("[]"));
 	}
 
 	@DisplayName("영상 삭제 - 잘못된 videoId")
@@ -148,7 +154,8 @@ class MetadataControllerTest {
 		String url = BASE_URL + "/" + "wrong-id";
 
 		// when
-		mockMvc.perform(delete(url))
+		mockMvc.perform(delete(url)
+                .header(JwtUtils.JWT_HEADER, TestUtils.DEFAULT_JWT))
 			.andExpect(status().isNotFound());
 
 		// then


### PR DESCRIPTION
# 📋 내용
JWT 기반 소유자 검증 로직을 블랙박스 및 메타데이터 API에 적용하고, 
권한 없는 접근 시 403 Forbidden 처리 추가
<!-- 작업 내용을 여기에 적어주세요 -->
## [블랙박스]

### 서비스

- `rename` 메서드에 사용자 ID와 블랙박스 소유자 ID 비교 로직 추가
- 주인이 아닌 사용자가 블랙박스 이름을 변경할 경우 `AuthorizationException` 발생 및 FORBIDDEN 에러 메시지 반환

### 컨트롤러

- `rename` API에서 JWT 토큰 헤더를 통해 userId 추출 후 서비스 레이어 전달
- Swagger 문서에 403(권한 없음) 응답 코드 명시

## [메타데이터]

### 서비스

- `list` 및 `delete` 메서드에서 블랙박스 소유자와 요청 사용자 비교
- 소유자 불일치 시 `AuthorizationException` 발생
- 주인이 아닌 사용자의 조회/삭제 접근 차단

### 컨트롤러

- JWT 토큰을 통해 userId 추출 후 서비스 레이어 전달
- 403(권한 없음) 응답 코드 명시
- 주인이 아닌 사용자의 접근을 차단하도록 API 연동

## [Global 핸들러]

- `AuthorizationException` 전용 처리 메서드 추가
- 예외 발생 시 403 Forbidden 상태 코드와 메시지 반환

## [테스트]

- MetadataController 테스트에 JWT 토큰 헤더 추가
