### PR TITLE
[#146] refactor: 액세스 키 제거하고 OIDC 방식으로 변경

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
 
     steps:
@@ -53,8 +54,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::622703417916:role/github-actions-ecr-push-role
           aws-region: ap-northeast-2
 
       - name: Login to Amazon ECR


### PR DESCRIPTION
Closes #146

# 📋 내용

<!-- 작업 내용을 여기에 적어주세요 -->
- GitHub Actions의 AWS 인증 방식을 OIDC 기반으로 전환
- 기존에 Secrets에 저장한 액세스 키 대신, 워크플로 실행 시 OIDC 토큰으로 IAM Role을 Assume하여 임시 자격 증명을 발급받도록 변경